### PR TITLE
package.json: Use correct name for highlight.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/oldes/highlightjs-redbol#readme",
   "dependencies": {
-    "highlightjs": "^11.9.0"
+    "highlight.js": "^11.9.0"
   }
 }


### PR DESCRIPTION
Official highlight.js npm package is named `highlight.js`, not `highlightjs`.

This fixes dependencies retrieval using npm or yarn as there is no version 11.9.0 for `highlightjs` package, see below:

```
$ yarn add highlightjs-redbol
Couldn't find any versions for "highlightjs" that matches "^11.9.0"
? Please choose a version of "highlightjs" from this list: (Use arrow keys)
❯ 9.16.2 
  9.12.0 
  9.10.0 
  9.8.0 
  8.7.0 
```



For the record, I got already hit by this issue, see https://github.com/highlightjs/highlight.js/issues/1874.